### PR TITLE
Update and correct support email

### DIFF
--- a/config/gen3/login.json
+++ b/config/gen3/login.json
@@ -11,7 +11,7 @@
   ],
   "bottomContent": [
     {
-      "text": "If you have any questions about access or the registration process, please contact gen3@datacommons.io.",
+      "text": "If you have any questions about access or the registration process, please contact support@gen3.org.",
       "className": "text-center text-sm"
     }
   ],


### PR DESCRIPTION
Corrected and updated email address from gen3@datacommons.io to support@gen3.org