### PR TITLE
(PROM-111): bump frontend framework version to 0.10.47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@fontsource/montserrat": "^5.0.19",
         "@fontsource/poppins": "^5.0.15",
         "@fontsource/source-sans-pro": "^5.0.8",
-        "@gen3/core": "^0.10.46",
-        "@gen3/frontend": "^0.10.46",
+        "@gen3/core": "^0.10.47",
+        "@gen3/frontend": "^0.10.47",
         "@grafana/faro-react": "^1.9.1",
         "@grafana/faro-web-sdk": "^1.9.1",
         "@grafana/faro-web-tracing": "^1.9.1",
@@ -28,12 +28,12 @@
         "cookies-next": "^4.1.1",
         "mantine-react-table": "^2.0.0-beta.6",
         "react": "^18.2.0",
-        "react-dom": "18.2.0",
+        "react-dom": "^18.2.0",
         "sharp": "^0.33.5",
         "swr": "^2.2.5"
       },
       "devDependencies": {
-        "@gen3/toolsff": "^0.10.46",
+        "@gen3/toolsff": "^0.10.47",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/line-clamp": "^0.4.2",
@@ -67,7 +67,7 @@
         "npm": ">=10.2.3"
       },
       "peerDependencies": {
-        "@gen3/core": "^0.10.46",
+        "@gen3/core": "^0.10.47",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
@@ -1654,10 +1654,9 @@
       "license": "OFL-1.1"
     },
     "node_modules/@gen3/core": {
-      "version": "0.10.46",
-      "resolved": "https://registry.npmjs.org/@gen3/core/-/core-0.10.46.tgz",
-      "integrity": "sha512-ABjezefk7yogJ6OGy4NzLDrXz5NF0bWS0D4hEhASshen2CzhI46IwPQP/kzJG4jLZeAmqK17EEUw0Zdt4JjSnw==",
-      "license": "Apache-2.0",
+      "version": "0.10.47",
+      "resolved": "https://registry.npmjs.org/@gen3/core/-/core-0.10.47.tgz",
+      "integrity": "sha512-4Ozdn0Vn2a9MBnxpb7kCmmgoUL/Kn7zRCs9ba0foqJ9MOwo8cOFL2bgDaqDR/fxiKD1lmqK5xFU2KfqvwD1I6w==",
       "dependencies": {
         "@reduxjs/toolkit": "1.9.5",
         "flat": "^6.0.1",
@@ -1678,10 +1677,9 @@
       }
     },
     "node_modules/@gen3/frontend": {
-      "version": "0.10.46",
-      "resolved": "https://registry.npmjs.org/@gen3/frontend/-/frontend-0.10.46.tgz",
-      "integrity": "sha512-2RkOwZec6YvGndLGAiTWdK7LqXy8+O02UubvWnpx3UgEnG7dayXPK5loE96duXSQV2AxwnhX9kF3/L5ZXoTzRg==",
-      "license": "Apache-2.0",
+      "version": "0.10.47",
+      "resolved": "https://registry.npmjs.org/@gen3/frontend/-/frontend-0.10.47.tgz",
+      "integrity": "sha512-WD+BSRxa50YFk6KQfFaGrMTDs9gnVWJIMN+wQGkRq06B3Me3xakNStnvqQVgiQAvakPMWLlew0qctgfx4gABFg==",
       "dependencies": {
         "@graphiql/react": "^0.23.1",
         "@iconify/react": "^4.0.1",
@@ -1806,11 +1804,10 @@
       }
     },
     "node_modules/@gen3/toolsff": {
-      "version": "0.10.46",
-      "resolved": "https://registry.npmjs.org/@gen3/toolsff/-/toolsff-0.10.46.tgz",
-      "integrity": "sha512-DPinhAIdd0uQm9aYG3j/fjqVcKgmzmDXpoceNsR68t6DvS7mFF2GiXEmFFiFVcRvigR+HmcIFmMbm4XL9rfTZw==",
+      "version": "0.10.47",
+      "resolved": "https://registry.npmjs.org/@gen3/toolsff/-/toolsff-0.10.47.tgz",
+      "integrity": "sha512-H5IcQ5pXYFr/YZaaJh+RQirf3eHnWCDPihw98Or0jgCT4fSxCsjN48Ej+npyfKkWORW5v2r6VIeorxyYneclcQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@iconify/tools": "^2.1.2",
         "tinycolor2": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "@fontsource/montserrat": "^5.0.19",
     "@fontsource/poppins": "^5.0.15",
     "@fontsource/source-sans-pro": "^5.0.8",
-    "@gen3/core": "^0.10.46",
-    "@gen3/frontend": "^0.10.46",
+    "@gen3/core": "^0.10.47",
+    "@gen3/frontend": "^0.10.47",
     "@grafana/faro-react": "^1.9.1",
     "@grafana/faro-web-sdk": "^1.9.1",
     "@grafana/faro-web-tracing": "^1.9.1",
@@ -43,7 +43,7 @@
     "swr": "^2.2.5"
   },
   "devDependencies": {
-    "@gen3/toolsff": "^0.10.46",
+    "@gen3/toolsff": "^0.10.47",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
@@ -73,7 +73,7 @@
     "typescript": "5.6.2"
   },
   "peerDependencies": {
-    "@gen3/core": "^0.10.46",
+    "@gen3/core": "^0.10.47",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }


### PR DESCRIPTION
Link to JIRA ticket if there is one: 

### New Features
- bump frontend framework version to 0.10.47
- includes discovery page graphs 
