### PR TITLE
change Data Commons graph to show data from metabolomics and VMOAT

### DIFF
--- a/config/gen3/discovery.json
+++ b/config/gen3/discovery.json
@@ -207,7 +207,7 @@
         },
         {
           "name": "Data Commons",
-          "field": "commons",
+          "field": "data_source",
           "errorIfNotAvailable": false,
           "valueIfNotAvailable": "",
           "contentType": "link",
@@ -524,7 +524,7 @@
         },
         {
           "name": "Data Commons",
-          "field": "commons",
+          "field": "data_source",
           "errorIfNotAvailable": false,
           "valueIfNotAvailable": "n/a",
           "contentType": "link",
@@ -597,7 +597,7 @@
               },
               {
                 "name": "Data Commons",
-                "field": "commons",
+                "field": "data_source",
                 "contentType": "string",
                 "includeIfNotAvailable": true,
                 "params": {


### PR DESCRIPTION
### Bug Fixes
Fixing config to change Data Commons graph and use `data_source` field to show data from metabolomics and VMOAT
