### PR TITLE
add new tab of RCC in data connection page

### DIFF
--- a/src/pages/DataConnections.tsx
+++ b/src/pages/DataConnections.tsx
@@ -112,6 +112,14 @@ const StatsPage = ({ headerProps, footerProps }: NavPageLayoutProps) => {
       "type": "API",
       "status": "[No Clinical Data, Imaging Data Received - Connection Pending]",
       "patients": "0/1878 Imaging data for 24 patients"
+    },
+    {
+      "source": "RCC",
+      "cohortStudy": "Cohort F",
+      "description": "Conduct analysis of collaborative workspaces on RCC pilot (pre-publication study)",
+      "type": "Collaborative workspace (VPODC/MC2DP)",
+      "status": "[Data Mounted on Collaborative Workspace]",
+      "patients": "23/23"
     }
   ];
   type BgColorsType = {[key: string]: string};


### PR DESCRIPTION
Link to JIRA ticket if there is one: [MC2DP-813](https://ctds-planx.atlassian.net/browse/MC2DP-813)

## Changes
- Added a new row in the Data Connection tab for RCC

[MC2DP-813]: https://ctds-planx.atlassian.net/browse/MC2DP-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ